### PR TITLE
Surveys sync with API and fixes

### DIFF
--- a/src/apps/survey/ingv-config-survey.ts
+++ b/src/apps/survey/ingv-config-survey.ts
@@ -7,6 +7,9 @@ export interface ItemSummary {
   id: string;
   lastModifiedMs: number;
   coordinates: number[];
+  projectedCoordinates: number[];
+  modifiedOffline?: boolean;
+  title?: string;
 }
 
 export type Context = {
@@ -15,15 +18,28 @@ export type Context = {
 
 export type Item = ItemSummary;
 
-export interface ISurveyConfig<ItemSummaryType = ItemSummary, ItemType = Item>
-  extends INgvStructureApp {
+export type ItemSaveResponse = {
+  id?: string;
+  message?: string;
+};
+
+export interface ISurveyConfig<
+  ItemSummaryType = ItemSummary,
+  ItemType = Item,
+  ItemSaveResponseType = ItemSaveResponse,
+> extends INgvStructureApp {
   app: {
     cesiumContext: IngvCesiumContext;
     survey: {
       listItems: (context: Context) => Promise<ItemSummaryType[]>;
       getItem: (context: Context) => Promise<ItemType>;
+      saveItem: (context: ItemType) => Promise<ItemSaveResponseType>;
       itemToFields: (item: ItemType) => FieldValues;
-      fieldsToItem: (values: FieldValues) => ItemType;
+      fieldsToItem: (
+        fields: FieldValues,
+        viewId?: string,
+        itemNumber?: number,
+      ) => ItemType;
       fields: SurveyField[];
     };
   };

--- a/src/plugins/cesium/ngv-plugin-cesium-offline.ts
+++ b/src/plugins/cesium/ngv-plugin-cesium-offline.ts
@@ -104,11 +104,17 @@ export class NgvPluginCesiumOffline extends LitElement {
     }
     this.loading = true;
     const offline = !this.offline;
-    const dir = await getOrCreateDirectoryChain([this.info.appName]);
 
     if (this.beforeSwitchDispatch) {
-      await this.beforeSwitchDispatch(offline);
+      try {
+        await this.beforeSwitchDispatch(offline);
+      } catch (error) {
+        console.error(error);
+        this.loading = false;
+        return;
+      }
     }
+    const dir = await getOrCreateDirectoryChain([this.info.appName]);
 
     if (offline) {
       if (this.info.view?.offline?.rectangle?.length) {

--- a/src/plugins/ui/ngv-layers-list.ts
+++ b/src/plugins/ui/ngv-layers-list.ts
@@ -9,6 +9,7 @@ export type LayerListItem = {
 export type LayerListOptions = {
   title?: string;
   showDeleteBtns?: boolean;
+  showDeleteBtnCallback?: (index: number) => boolean;
   showZoomBtns?: boolean;
   showEditBtns?: boolean;
 };
@@ -58,7 +59,11 @@ export class NgvLayersList extends LitElement {
                     &#128393
                   </wa-icon-button>`
                   : ''}
-                ${this.options?.showDeleteBtns
+                ${(
+                  this.options?.showDeleteBtnCallback
+                    ? this.options.showDeleteBtnCallback(i)
+                    : this.options?.showDeleteBtns
+                )
                   ? html`<wa-icon-button
                       src="../../../icons/trash.svg"
                       size="small"

--- a/src/utils/generalTypes.ts
+++ b/src/utils/generalTypes.ts
@@ -1,13 +1,16 @@
 import type {TemplateResult} from 'lit';
 
-export type Coordinate = {longitude: number; latitude: number; height: number};
+export type Coordinates = {
+  wgs84: number[];
+  projected?: number[];
+};
 
 export type FieldValues = Record<
   string,
   | string
   | number
   | Record<string, boolean>
-  | Coordinate
+  | Coordinates
   | number[]
   | TemplateResult<1>
 >;

--- a/styles/index.css
+++ b/styles/index.css
@@ -41,7 +41,7 @@ wa-card.ngv-toolbar::part(body) {
 }
 
 .ngv-toolbar > img {
-  max-width: initial;
+  max-width: fit-content;
 }
 
 wa-details.ngv-vertical-menu {


### PR DESCRIPTION
1. Made it possible to save or update surveys
2. Surveys sync with API when back online 
               -  Surveys that failed to sync will be shown in a separate list

Fixes:
1. Fixed inconsistencies between WGS84 and projected coordinates in different places
4. Fixed the wrong defect color on the map after creating or highlighting

Improvements:
1. Changed the way of survey form loading and added a preloader
2. Made the title in the list more informative
5. The delete button is shown only for defects created offline until it is synced, as there is no delete endpoint yet